### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM mhart/alpine-node:14 
+
+RUN npm i -g moser
+
+cmd ["moser", "--mongo", "mongodb://localhost:27017"]


### PR DESCRIPTION
I loved the simplicity of using moser and liked how similar it was to json-server, 

Please accept a Dockerfile that installs moser from npm for use in a CI environment to build containers with the latest version of moser 